### PR TITLE
Update for python3 and move top level into if block

### DIFF
--- a/ndiff.py
+++ b/ndiff.py
@@ -30,7 +30,7 @@ def read_data(hval):
 # creates and returns a summary description for every element in a group
 def evaluate_group(path, grp):
     desc = {}
-    for k,v in grp.iteritems():
+    for k,v in grp.items():
         if isinstance(v, h5py.Dataset):
             desc[k] = read_data(v)
         elif isinstance(v, h5py.Group):
@@ -40,30 +40,34 @@ def evaluate_group(path, grp):
     return desc
 
 def diff_groups(file1, grp1, file2, grp2, path):
-    print "------------------------------"
-    print "Examining " + path
+    print("------------------------------")
+    print("Examining " + path)
     desc1 = evaluate_group(path, grp1)
     desc2 = evaluate_group(path, grp2)
     common = []
+    differs = False
     for k in desc1:
         if k in desc2:
             common.append(k)
         else:
-            print "** Element '%s' only in '%s' (DIFF_UNIQUE_A)**" % (k, file1)
+            print("** Element '%s' only in '%s' (DIFF_UNIQUE_A)**" % (k, file1))
+            differs = True
     for k in desc2:
         if k not in desc1:
-            print "** Element '%s' only in '%s' (DIFF_UNIQUE_B)**" % (k, file2)
+            print("** Element '%s' only in '%s' (DIFF_UNIQUE_B)**" % (k, file2))
+            differs = True
     for i in range(len(common)):
         name = common[i]
-        print "\t" + name
+        print("\t" + name)
         # compare types
         h1 = desc1[name]["htype"]
         h2 = desc2[name]["htype"]
         if h1 != h2:
-            print "**  Different element types: '%s' and '%s' (DIFF_OBJECTS)" % (h1, h2)
+            print("**  Different element types: '%s' and '%s' (DIFF_OBJECTS)" % (h1, h2))
+            differs = True
             continue    # different hdf5 types -- don't try to compare further
         if h1 != "dataset" and h1 != "group":
-            print "WARNING: element is not a recognized type (%s) and isn't being evaluated" % h1
+            print("WARNING: element is not a recognized type (%s) and isn't being evaluated" % h1)
             continue
         # handle datasets first
         if desc1[name]["htype"] != "dataset":
@@ -73,20 +77,24 @@ def diff_groups(file1, grp1, file2, grp2, path):
         if desc1[name]["dtype"] != desc2[name]["dtype"]:
             d1 = desc1[name]["dtype"]
             d2 = desc2[name]["dtype"]
-            print "** Different dtypes: '%s' and '%s' (DIFF_DTYPE)**" % (d1, d2)
+            print("** Different dtypes: '%s' and '%s' (DIFF_DTYPE)**" % (d1, d2))
+            differs = True
         # compare attributes
         for k in desc1[name]["attr"]:
             if k not in desc2[name]["attr"]:
-                print "** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_A)**" % (k, file1)
+                print("** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_A)**" % (k, file1))
+                differs = True
         for k in desc2[name]["attr"]:
             if k not in desc1[name]["attr"]:
-                print "** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_B)**" % (k, file2)
+                print("** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_B)**" % (k, file2))
+                differs = True
         for k in desc1[name]["attr"]:
             if k in desc2[name]["attr"]:
                 v = desc1[name]["attr"][k]
                 v2 = desc2[name]["attr"][k]
                 if v != v2:
-                    print "** Attribute '%s' has different type: '%s' and '%s' (DIFF_ATTR_DTYPE)" % (k, v, v2)
+                    print("** Attribute '%s' has different type: '%s' and '%s' (DIFF_ATTR_DTYPE)" % (k, v, v2))
+                    differs = True
     for i in range(len(common)):
         name = common[i]
         # compare types
@@ -97,32 +105,37 @@ def diff_groups(file1, grp1, file2, grp2, path):
         # compare attributes
         for k in desc1[name]["attr"]:
             if k not in desc2[name]["attr"]:
-                print "** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_A)**" % (k, file1)
+                print("** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_A)**" % (k, file1))
+                differs = True
         for k in desc2[name]["attr"]:
             if k not in desc1[name]["attr"]:
-                print "** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_B)**" % (k, file2)
+                print("** Attribute '%s' only in '%s' (DIFF_UNIQ_ATTR_B)**" % (k, file2))
+                differs = True
         # recurse into subgroup
         diff_groups(file1, grp1[name], file2, grp2[name], path+name+"/")
+    return differs
 
 
 def diff_files(file1, file2):
-    print "Comparing '%s' and '%s'" % (file1, file2)
+    print("Comparing '%s' and '%s'" % (file1, file2))
     try:
         f1 = h5py.File(file1, 'r')
     except IOError:
-        print "Unable to open file '%s'" % file1
+        print("Unable to open file '%s'" % file1)
         sys.exit(1)
     try:
         f2 = h5py.File(file2, 'r')
     except IOError:
-        print "Unable to open file '%s'" % file2
+        print("Unable to open file '%s'" % file2)
         sys.exit(1)
-    diff_groups(file1, f1["/"], file2, f2["/"], "/")
+    return diff_groups(file1, f1["/"], file2, f2["/"], "/")
 
-if len(sys.argv) != 3:
-    print "Usage: %s <file1.h5> <file2.h5>" % sys.argv[0]
-    sys.exit(1)
+if __name__=="__main__":
+    if len(sys.argv) != 3:
+        print("Usage: %s <file1.h5> <file2.h5>" % sys.argv[0])
+        sys.exit(2)
 
-diff_files(sys.argv[1], sys.argv[2])
+    if diff_files(sys.argv[1], sys.argv[2]):
+        sys.exit(1)
 
-
+    sys.exit(0)


### PR DESCRIPTION
I made some changes to be able to import ndiff as a module into an existing python3 project.

- Update the print statements to python3 style
- Replace iteritems() to items() (python3)
- Move the top level code into `if __name__=="__main__":` block.

Not sure if you'd need additional updates to the README or elsewhere (#! line?) to explicitly require python3. Hope this is useful.